### PR TITLE
Fix build output dir

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -4,4 +4,7 @@ import react from "@vitejs/plugin-react";
 export default defineConfig({
   plugins: [react()],
   root: "src",
+  build: {
+    outDir: "../dist",
+  },
 });


### PR DESCRIPTION
The dist dir was being generated inside the src folder and causes eslint to fail.